### PR TITLE
Fix product updating

### DIFF
--- a/src-tauri/src/dlsite/mod.rs
+++ b/src-tauri/src/dlsite/mod.rs
@@ -158,8 +158,10 @@ pub async fn update_product(mut on_progress: impl FnMut(usize, usize) -> Result<
                     _ => return Err(err),
                 },
             };
-            prev_product_count += products.len();
-            progress += products.len();
+
+            let updated_prev_product_count = (page - 1) * PAGE_LIMIT + products.len();
+            progress += updated_prev_product_count - prev_product_count;
+            prev_product_count = updated_prev_product_count;
 
             on_progress(progress, total_progress)?;
 


### PR DESCRIPTION
The product update counting sometimes works incorrectly when amount of new products crosses pagination boundary

Example:
Imagine user has 40 products in library (prev_product_count = 40) and purchases 20 more (new_product_count = 60)

Current sync will fetch page 1 (products 0-49)

- products.len() = 50, PAGE_LIMIT
- prev_product_count += 50 // prev_product_count = 90, wrong, only 10 new products on this page
- prev_product_count (90) >= new_product_count (60), end without fetching page 2 (products 50-59)

The new code sets prev_product_count to (sum of products from all previous pages + products on current page)

Hope this explanation makes sense, it solved my issue

<sub>Thanks for the tool, its been very useful to me</sub>